### PR TITLE
New message types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,14 @@
 node_modules
 dist
 yarn-error.log
+
+# Devenv
+.devenv*
+devenv.local.nix
+
+# direnv
+.direnv
+.env*
+
+# pre-commit
+.pre-commit-config.yaml

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ export enum V0MessageType {
   Address = "address",
   ExtendedPublicKey = "extendedPublicKey",
   PaymentRequest = "paymentRequest",
+  Payment = "payment",
   Close = "close",
 }
 
@@ -77,6 +78,12 @@ export type PaymentRequestV0Message = {
   slip24: Slip24 | null;
 };
 
+export type PaymentV0Message = {
+  version: MessageVersion.V0;
+  type: V0MessageType.Payment;
+  txid: string;
+};
+
 export type CloseV0Message = {
   version: MessageVersion.V0;
   type: V0MessageType.Close;
@@ -89,6 +96,7 @@ export type Message =
   | AddressV0Message
   | ExtendedPublicKeyV0Message
   | PaymentRequestV0Message
+  | PaymentV0Message
   | CloseV0Message;
 
 export function serializeMessage(message: Message) {
@@ -238,6 +246,17 @@ export function parseMessage(value: any): Message {
         label,
         message,
         slip24: parseSlip24(slip24),
+      };
+    } else if (type === V0MessageType.Payment) {
+      const { txid } = object;
+      if (!isString(txid)) {
+        throw new Error("txid missing");
+      }
+
+      return {
+        version,
+        type,
+        txid,
       };
     } else if (type === V0MessageType.Close) {
       return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,76 +1,85 @@
-import { parseSlip24, type Slip24 } from './slip24';
-import { isBoolean, isLiteral, isNull, isNullish, isNumber, isObject, isOneOf, isString } from './utils';
+import { parseSlip24, type Slip24 } from "./slip24";
+import {
+  isBoolean,
+  isLiteral,
+  isNull,
+  isNullish,
+  isNumber,
+  isObject,
+  isOneOf,
+  isString,
+} from "./utils";
 
-export { type Slip24 } from './slip24';
+export { type Slip24 } from "./slip24";
 
 export enum MessageVersion {
-  V0 = '0',
+  V0 = "0",
 }
 
 export enum V0MessageType {
-  RequestAddress = 'requestAddress',
-  RequestExtendedPublicKey = 'requestExtendedPublicKey',
-  VerifyAddress = 'verifyAddress',
-  Address = 'address',
-  ExtendedPublicKey = 'extendedPublicKey',
-  PaymentRequest = 'paymentRequest',
-  Close = 'close',
+  RequestAddress = "requestAddress",
+  RequestExtendedPublicKey = "requestExtendedPublicKey",
+  VerifyAddress = "verifyAddress",
+  Address = "address",
+  ExtendedPublicKey = "extendedPublicKey",
+  PaymentRequest = "paymentRequest",
+  Close = "close",
 }
 
 export enum V0MessageScriptType {
-  P2PKH = 'p2pkh',
-  P2WPKH = 'p2wpkh',
-  P2SH = 'p2sh',
-  P2TR = 'p2tr',
+  P2PKH = "p2pkh",
+  P2WPKH = "p2wpkh",
+  P2SH = "p2sh",
+  P2TR = "p2tr",
 }
 
 export type RequestAddressV0Message = {
-  version: MessageVersion.V0,
-  type: V0MessageType.RequestAddress,
-  withMessageSignature?: string | false | null,
-  withExtendedPublicKey?: boolean | null,
-  withScriptType?: V0MessageScriptType | null,
+  version: MessageVersion.V0;
+  type: V0MessageType.RequestAddress;
+  withMessageSignature?: string | false | null;
+  withExtendedPublicKey?: boolean | null;
+  withScriptType?: V0MessageScriptType | null;
 };
 
 export type RequestExtendedPublicKeyV0Message = {
-  version: MessageVersion.V0,
-  type: V0MessageType.RequestExtendedPublicKey,
-  withScriptType?: V0MessageScriptType | null,
+  version: MessageVersion.V0;
+  type: V0MessageType.RequestExtendedPublicKey;
+  withScriptType?: V0MessageScriptType | null;
 };
 
 export type VerifyAddressV0Message = {
-  version: MessageVersion.V0,
-  type: V0MessageType.VerifyAddress,
-  bitcoinAddress: string,
+  version: MessageVersion.V0;
+  type: V0MessageType.VerifyAddress;
+  bitcoinAddress: string;
 };
 
 export type AddressV0Message = {
-  version: MessageVersion.V0,
-  type: V0MessageType.Address,
-  bitcoinAddress: string,
-  signature?: string | null,
-  extendedPublicKey?: string | null,
+  version: MessageVersion.V0;
+  type: V0MessageType.Address;
+  bitcoinAddress: string;
+  signature?: string | null;
+  extendedPublicKey?: string | null;
 };
 
 export type ExtendedPublicKeyV0Message = {
-  version: MessageVersion.V0,
-  type: V0MessageType.ExtendedPublicKey,
-  extendedPublicKey: string,
+  version: MessageVersion.V0;
+  type: V0MessageType.ExtendedPublicKey;
+  extendedPublicKey: string;
 };
 
 export type PaymentRequestV0Message = {
-  version: MessageVersion.V0,
-  type: V0MessageType.PaymentRequest,
-  bitcoinAddress: string,
-  amount: number,
-  label: string | null,
-  message: string | null,
-  slip24: Slip24 | null,
+  version: MessageVersion.V0;
+  type: V0MessageType.PaymentRequest;
+  bitcoinAddress: string;
+  amount: number;
+  label: string | null;
+  message: string | null;
+  slip24: Slip24 | null;
 };
 
 export type CloseV0Message = {
-  version: MessageVersion.V0,
-  type: V0MessageType.Close,
+  version: MessageVersion.V0;
+  type: V0MessageType.Close;
 };
 
 export type Message =
@@ -89,16 +98,16 @@ export function serializeMessage(message: Message) {
 export function parseMessage(value: any): Message {
   let object = value;
 
-  if (typeof object === 'string') {
+  if (typeof object === "string") {
     try {
       object = JSON.parse(object);
     } catch (e) {
-      throw new Error('could not parse as json');
+      throw new Error("could not parse as json");
     }
   }
 
   if (!isObject(object)) {
-    throw new Error('not an object');
+    throw new Error("not an object");
   }
 
   const { version } = object;
@@ -107,23 +116,29 @@ export function parseMessage(value: any): Message {
     const { type } = object;
 
     if (!isOneOf(type, ...Object.values(V0MessageType))) {
-      throw new Error('invalid type');
+      throw new Error("invalid type");
     }
 
     if (type === V0MessageType.RequestAddress) {
       const { withMessageSignature } = object;
       if (!isString(withMessageSignature) && !isNullish(withMessageSignature)) {
-        throw new Error('message signature indicator invalid');
+        throw new Error("message signature indicator invalid");
       }
 
       const { withExtendedPublicKey } = object;
-      if (!isBoolean(withExtendedPublicKey) && !isNullish(withExtendedPublicKey)) {
-        throw new Error('extended public key indicator invalid');
+      if (
+        !isBoolean(withExtendedPublicKey) &&
+        !isNullish(withExtendedPublicKey)
+      ) {
+        throw new Error("extended public key indicator invalid");
       }
 
       const { withScriptType } = object;
-      if (!isOneOf(withScriptType, ...Object.values(V0MessageScriptType)) && !isNullish(withScriptType)) {
-        throw new Error('script type indicator invalid');
+      if (
+        !isOneOf(withScriptType, ...Object.values(V0MessageScriptType)) &&
+        !isNullish(withScriptType)
+      ) {
+        throw new Error("script type indicator invalid");
       }
 
       return {
@@ -135,8 +150,11 @@ export function parseMessage(value: any): Message {
       };
     } else if (type === V0MessageType.RequestExtendedPublicKey) {
       const { withScriptType } = object;
-      if (!isOneOf(withScriptType, ...Object.values(V0MessageScriptType)) && !isNullish(withScriptType)) {
-        throw new Error('script type indicator invalid');
+      if (
+        !isOneOf(withScriptType, ...Object.values(V0MessageScriptType)) &&
+        !isNullish(withScriptType)
+      ) {
+        throw new Error("script type indicator invalid");
       }
 
       return {
@@ -147,7 +165,7 @@ export function parseMessage(value: any): Message {
     } else if (type === V0MessageType.VerifyAddress) {
       const { bitcoinAddress } = object;
       if (!isString(bitcoinAddress)) {
-        throw new Error('bitcoin address missing');
+        throw new Error("bitcoin address missing");
       }
 
       return {
@@ -158,17 +176,17 @@ export function parseMessage(value: any): Message {
     } else if (type === V0MessageType.Address) {
       const { bitcoinAddress } = object;
       if (!isString(bitcoinAddress)) {
-        throw new Error('bitcoin address missing');
+        throw new Error("bitcoin address missing");
       }
 
       const { signature } = object;
       if (!isString(signature) && !isNullish(signature)) {
-        throw new Error('signature invalid');
+        throw new Error("signature invalid");
       }
 
       const { extendedPublicKey } = object;
       if (!isString(extendedPublicKey) && !isNullish(extendedPublicKey)) {
-        throw new Error('extended public key invalid');
+        throw new Error("extended public key invalid");
       }
 
       return {
@@ -181,7 +199,7 @@ export function parseMessage(value: any): Message {
     } else if (type === V0MessageType.ExtendedPublicKey) {
       const { extendedPublicKey } = object;
       if (!isString(extendedPublicKey)) {
-        throw new Error('extended public key missing');
+        throw new Error("extended public key missing");
       }
 
       return {
@@ -192,22 +210,22 @@ export function parseMessage(value: any): Message {
     } else if (type === V0MessageType.PaymentRequest) {
       const { bitcoinAddress } = object;
       if (!isString(bitcoinAddress)) {
-        throw new Error('bitcoin address invalid');
+        throw new Error("bitcoin address invalid");
       }
 
       const { amount } = object;
       if (!isNumber(amount)) {
-        throw new Error('amount invalid');
+        throw new Error("amount invalid");
       }
 
       const { label } = object;
       if (!isString(label) && !isNull(label)) {
-        throw new Error('label invalid');
+        throw new Error("label invalid");
       }
 
       const { message } = object;
       if (!isString(message) && !isNull(message)) {
-        throw new Error('message invalid');
+        throw new Error("message invalid");
       }
 
       const { slip24 } = object;
@@ -219,7 +237,7 @@ export function parseMessage(value: any): Message {
         amount,
         label,
         message,
-        slip24: parseSlip24(slip24)
+        slip24: parseSlip24(slip24),
       };
     } else if (type === V0MessageType.Close) {
       return {
@@ -227,9 +245,9 @@ export function parseMessage(value: any): Message {
         type,
       };
     } else {
-      throw new Error('unsupported type');
+      throw new Error("unsupported type");
     }
   }
 
-  throw new Error('unsupported version');
+  throw new Error("unsupported version");
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ export enum V0MessageScriptType {
 export type RequestAddressV0Message = {
   version: MessageVersion.V0;
   type: V0MessageType.RequestAddress;
+  correlationId?: string;
   withMessageSignature?: string | false | null;
   withExtendedPublicKey?: boolean | null;
   withScriptType?: V0MessageScriptType | null;
@@ -46,18 +47,21 @@ export type RequestAddressV0Message = {
 export type RequestExtendedPublicKeyV0Message = {
   version: MessageVersion.V0;
   type: V0MessageType.RequestExtendedPublicKey;
+  correlationId?: string;
   withScriptType?: V0MessageScriptType | null;
 };
 
 export type VerifyAddressV0Message = {
   version: MessageVersion.V0;
   type: V0MessageType.VerifyAddress;
+  correlationId?: string;
   bitcoinAddress: string;
 };
 
 export type AddressV0Message = {
   version: MessageVersion.V0;
   type: V0MessageType.Address;
+  correlationId?: string;
   bitcoinAddress: string;
   signature?: string | null;
   extendedPublicKey?: string | null;
@@ -66,12 +70,14 @@ export type AddressV0Message = {
 export type ExtendedPublicKeyV0Message = {
   version: MessageVersion.V0;
   type: V0MessageType.ExtendedPublicKey;
+  correlationId?: string;
   extendedPublicKey: string;
 };
 
 export type PaymentRequestV0Message = {
   version: MessageVersion.V0;
   type: V0MessageType.PaymentRequest;
+  correlationId?: string;
   bitcoinAddress: string;
   amount: number;
   label: string | null;
@@ -82,12 +88,16 @@ export type PaymentRequestV0Message = {
 export type PaymentV0Message = {
   version: MessageVersion.V0;
   type: V0MessageType.Payment;
+  correlationId?: string;
   txid: string;
 };
 
 export type CloseV0Message = {
   version: MessageVersion.V0;
   type: V0MessageType.Close;
+  correlationId?: string;
+};
+
 export type CancelV0Message = {
   version: MessageVersion.V0;
   type: V0MessageType.Cancel;
@@ -128,10 +138,14 @@ export function parseMessage(value: any): Message {
   const { version } = object;
 
   if (isLiteral(version, MessageVersion.V0 as const)) {
-    const { type } = object;
+    const { type, correlationId } = object;
 
     if (!isOneOf(type, ...Object.values(V0MessageType))) {
       throw new Error("invalid type");
+    }
+
+    if (!isString(correlationId) && correlationId !== undefined) {
+      throw new Error("correlation id invalid");
     }
 
     if (type === V0MessageType.RequestAddress) {
@@ -159,6 +173,7 @@ export function parseMessage(value: any): Message {
       return {
         version,
         type,
+        ...(correlationId ? { correlationId } : {}),
         withMessageSignature, // !true
         withExtendedPublicKey,
         withScriptType,
@@ -175,6 +190,7 @@ export function parseMessage(value: any): Message {
       return {
         version,
         type,
+        ...(correlationId ? { correlationId } : {}),
         withScriptType,
       };
     } else if (type === V0MessageType.VerifyAddress) {
@@ -186,6 +202,7 @@ export function parseMessage(value: any): Message {
       return {
         version,
         type,
+        ...(correlationId ? { correlationId } : {}),
         bitcoinAddress,
       };
     } else if (type === V0MessageType.Address) {
@@ -207,6 +224,7 @@ export function parseMessage(value: any): Message {
       return {
         version,
         type,
+        ...(correlationId ? { correlationId } : {}),
         bitcoinAddress,
         signature,
         extendedPublicKey,
@@ -220,6 +238,7 @@ export function parseMessage(value: any): Message {
       return {
         version,
         type,
+        ...(correlationId ? { correlationId } : {}),
         extendedPublicKey,
       };
     } else if (type === V0MessageType.PaymentRequest) {
@@ -248,6 +267,7 @@ export function parseMessage(value: any): Message {
       return {
         version,
         type,
+        ...(correlationId ? { correlationId } : {}),
         bitcoinAddress,
         amount,
         label,
@@ -263,6 +283,7 @@ export function parseMessage(value: any): Message {
       return {
         version,
         type,
+        ...(correlationId ? { correlationId } : {}),
         txid,
       };
     } else if (type === V0MessageType.Cancel) {
@@ -282,6 +303,7 @@ export function parseMessage(value: any): Message {
       return {
         version,
         type,
+        ...(correlationId ? { correlationId } : {}),
       };
     } else {
       throw new Error("unsupported type");

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export enum V0MessageType {
   PaymentRequest = "paymentRequest",
   Payment = "payment",
   Close = "close",
+  Cancel = "cancel",
 }
 
 export enum V0MessageScriptType {
@@ -87,6 +88,11 @@ export type PaymentV0Message = {
 export type CloseV0Message = {
   version: MessageVersion.V0;
   type: V0MessageType.Close;
+export type CancelV0Message = {
+  version: MessageVersion.V0;
+  type: V0MessageType.Cancel;
+  correlationId?: string;
+  reason?: string | null;
 };
 
 export type Message =
@@ -97,7 +103,8 @@ export type Message =
   | ExtendedPublicKeyV0Message
   | PaymentRequestV0Message
   | PaymentV0Message
-  | CloseV0Message;
+  | CloseV0Message
+  | CancelV0Message;
 
 export function serializeMessage(message: Message) {
   return JSON.stringify(message);
@@ -257,6 +264,19 @@ export function parseMessage(value: any): Message {
         version,
         type,
         txid,
+      };
+    } else if (type === V0MessageType.Cancel) {
+      const { reason } = object;
+
+      if (!isString(reason) && !isNullish(reason)) {
+        throw new Error("reason invalid");
+      }
+
+      return {
+        version,
+        type,
+        ...(correlationId ? { correlationId } : {}),
+        ...(reason !== undefined ? { reason } : {}),
       };
     } else if (type === V0MessageType.Close) {
       return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {
   isString,
 } from "./utils";
 
-export { type Slip24 } from "./slip24";
+export type { Slip24 } from "./slip24";
 
 export enum MessageVersion {
   V0 = "0",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,45 +1,72 @@
 /* eslint-env jest */
 
-import { parseMessage } from '../src';
+import { parseMessage } from "../src";
 
-describe('parse message', () => {
-  it('should parse correct message', () => {
-    for (const fixture of [
-      {
-        version: '0',
-        type: 'paymentRequest',
-        bitcoinAddress: 'bc1q',
-        amount: 0.01,
-        label: 'Merchant',
-        message: 'Elderberries',
-        slip24: {
-          recipientName: 'Merchant',
-          nonce: null,
-          memos: [{
-            type: 'text',
-            text: 'Elderberries',
-          }],
-          outputs: [{
-            address: 'tb1q2q0j6gmfxynj40p0kxsr9jkagcvgpuqvqynnup',
-            amount: 1000000,
-          }],
-          signature: 'abc',
+const correctMessageFixtures = [
+  {
+    version: "0",
+    type: "paymentRequest",
+    bitcoinAddress: "bc1q",
+    amount: 0.01,
+    label: "Merchant",
+    message: "Elderberries",
+    slip24: {
+      recipientName: "Merchant",
+      nonce: null,
+      memos: [
+        {
+          type: "text",
+          text: "Elderberries",
         },
-      }
-    ]) {
+      ],
+      outputs: [
+        {
+          address: "tb1q2q0j6gmfxynj40p0kxsr9jkagcvgpuqvqynnup",
+          amount: 1000000,
+        },
+      ],
+      signature: "abc",
+    },
+  },
+  {
+    version: "0",
+    type: "verifyAddress",
+    correlationId: "1234",
+    bitcoinAddress: "bc1q",
+  },
+  {
+    version: "0",
+    type: "cancel",
+  },
+  {
+    version: "0",
+    type: "cancel",
+    reason: null,
+  },
+  {
+    version: "0",
+    type: "cancel",
+    correlationId: "1234",
+    reason: "rejected_by_user",
+  },
+];
+
+describe("parse message", () => {
+  it("should parse correct message", () => {
+    for (const fixture of correctMessageFixtures) {
       expect(parseMessage(fixture)).toStrictEqual(fixture);
     }
   });
 
-  it('should fail incorrect message', () => {
+  it("should fail incorrect message", () => {
     for (const fixture of [
       null,
       undefined,
       {},
       [],
       {
-        version: 'incomplete',
-      }
+        version: "incomplete",
+      },
     ]) {
       expect(() => parseMessage(fixture)).toThrow();
     }


### PR DESCRIPTION
New message type `Payment` for the service or wallet to signal the payment previously requested in `paymentRequest` is broadcast.
```ts
export type PaymentV0Message = {
  version: MessageVersion.V0;
  type: V0MessageType.Payment;
  correlationId?: string;
  txid: string;
};
```

New message type `Cancel` for the service or wallet to signal the previously requested action was cancelled. Service or wallet can optionally specify a reason (e.g. `rejected_by_customer`).
```ts


export type CancelV0Message = {
  version: MessageVersion.V0;
  type: V0MessageType.Cancel;
  correlationId?: string;
  reason?: string | null;
};
```

Adding a new field `correlationId` to every message that allows to correlate request and response messages. This field is optional for now to be backwards compatible.